### PR TITLE
Add Tailwind monochrome palette option

### DIFF
--- a/code.ts
+++ b/code.ts
@@ -64,6 +64,29 @@ const easingFunctions = {
   'ease-in-out': (t: number) => t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2
 };
 
+// Generate Tailwind-like monochromatic color scale
+function generateTailwindScale(baseColor: string, steps: number, lightness: number, chroma: number): string[] {
+  const parsed = oklch(baseColor);
+  if (!parsed) {
+    throw new Error('Invalid color format');
+  }
+
+  const lStart = 0.98;
+  const lEnd = 0.12;
+  const baseChroma = Math.min(0.5, parsed.c || 0);
+  const colors: string[] = [];
+
+  for (let i = 0; i < steps; i++) {
+    const t = i / (steps - 1);
+    const targetL = lStart + (lEnd - lStart) * t;
+    const l = parsed.l * (1 - lightness) + targetL * lightness;
+    const c = baseChroma * chroma * (1 - 0.8 * Math.abs(2 * t - 1));
+    colors.push(formatHex({ mode: 'oklch', l, c, h: parsed.h || 0 }));
+  }
+
+  return colors;
+}
+
 
 
 function generateColorScale(baseColor: string, steps: number, lightness: number, chroma: number, method: string, mode: 'light' | 'dark' = 'light'): string[] {
@@ -92,6 +115,10 @@ function generateColorScale(baseColor: string, steps: number, lightness: number,
     }
 
     console.log('Base color parsed:', parsedColor);
+
+    if (method === 'tailwind') {
+      return generateTailwindScale(baseColor, steps, lightness, chroma);
+    }
 
     // Generate a proper color scale from light to dark
     const colors: Color[] = [];

--- a/ui.html
+++ b/ui.html
@@ -411,6 +411,7 @@
               <option value="ease-in">Ease In</option>
               <option value="ease-out">Ease Out</option>
               <option value="ease-in-out">Ease In-Out</option>
+              <option value="tailwind">Tailwind</option>
             </select>
             <div class="input-icon-container">
               <div class="input-icon">


### PR DESCRIPTION
## Summary
- implement `generateTailwindScale` for Tailwind-style monochromatic palettes
- call the new scale when interpolation method is set to `tailwind`
- expose a `Tailwind` option in the interpolation method dropdown

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688afe058afc832cab1ba06579d39e06